### PR TITLE
Allow access of aliases as symbols or strings just like its param

### DIFF
--- a/test/aviator/core/request_test.rb
+++ b/test/aviator/core/request_test.rb
@@ -243,6 +243,38 @@ class Aviator::Test
         req.params.the_param.must_equal param_val
         req.params.the_alias.must_equal param_val
       end
+      
+      
+      it 'allows aliases to be accessible as symbols' do
+        klass = Class.new(Aviator::Request) do
+                  param :the_param, required: true, alias: :the_alias
+                end
+        
+        param_val = 999
+        
+        req = klass.new do |params|
+                params[:the_alias] = param_val
+              end
+        
+        req.params[:the_param].must_equal param_val
+        req.params[:the_alias].must_equal param_val
+      end
+
+
+      it 'allows aliases to be accessible as strings' do
+        klass = Class.new(Aviator::Request) do
+                  param :the_param, required: true, alias: :the_alias
+                end
+        
+        param_val = 999
+        
+        req = klass.new do |params|
+                params['the_alias'] = param_val
+              end
+        
+        req.params['the_param'].must_equal param_val
+        req.params['the_alias'].must_equal param_val
+      end
     
     end
     


### PR DESCRIPTION
Prior to this rev, parameter aliases can only be access via dot
notation. This change allows one to use any of the following:

  keystone.request(:create_token) do |p|
    p[:tenant_name] = 'name'
  end

  keystone.request(:create_token) do |p|
    p['tenant_name'] = 'name'
  end

  keystone.request(:create_token) do |p|
    p.tenant_name = 'name'
  end
