### PR TITLE
Use underscored config keys for consistency

### DIFF
--- a/test/aviator/openstack/identity/v2/admin/create_user_test.rb
+++ b/test/aviator/openstack/identity/v2/admin/create_user_test.rb
@@ -147,7 +147,8 @@ class Aviator::Test
       service = session.identity_service
 
       tenant  = service.request(:list_tenants).body[:tenants].find do |t|
-                  t[:name] == Environment.openstack_admin[:auth_credentials][:tenantName]
+                  t[:name] == Environment.openstack_admin[:auth_credentials][:tenantName] ||
+                              Environment.openstack_admin[:auth_credentials][:tenant_name]
                 end
 
       response = service.request :create_user do |params|

--- a/test/aviator/openstack/identity/v2/public/create_token_test.rb
+++ b/test/aviator/openstack/identity/v2/public/create_token_test.rb
@@ -155,7 +155,8 @@ class Aviator::Test
 
       response = service.request :create_token do |params|
         params[:tokenId]    = token
-        params[:tenantName] = Environment.openstack_admin[:auth_credentials][:tenantName]
+        params[:tenantName] = Environment.openstack_admin[:auth_credentials][:tenantName] ||
+                              Environment.openstack_admin[:auth_credentials][:tenant_name]
       end
 
       response.status.must_equal 200

--- a/test/environment.yml.example
+++ b/test/environment.yml.example
@@ -16,7 +16,7 @@ openstack_admin:
   auth_credentials:
     username:   aviatortest_admin
     password:   aviatortest_password_admin
-    tenantName: aviatortest_project_admin
+    tenant_name: aviatortest_project_admin
 
 # This is expected by the test suite. You may change its values freely
 # as long as the name 'openstack_member' doesn't change and the user's
@@ -26,4 +26,4 @@ openstack_member:
   auth_credentials:
     username:   aviatortest_member
     password:   aviatortest_password_member
-    tenantName: aviatortest_project_member
+    tenant_name: aviatortest_project_member

--- a/test/environment.yml.travis-ci
+++ b/test/environment.yml.travis-ci
@@ -16,7 +16,7 @@ openstack_admin:
   auth_credentials:
     username:   aviatortest_admin
     password:   aviatortest_password_admin
-    tenantName: aviatortest_project_admin
+    tenant_name: aviatortest_project_admin
 
 # This is expected by the test suite. You may change its values freely
 # as long as the name 'openstack_member' doesn't change and the user's
@@ -26,4 +26,4 @@ openstack_member:
   auth_credentials:
     username:   aviatortest_member
     password:   aviatortest_password_member
-    tenantName: aviatortest_project_member
+    tenant_name: aviatortest_project_member

--- a/test/support/vcr_setup.rb
+++ b/test/support/vcr_setup.rb
@@ -20,9 +20,11 @@ VCR.configure do |c|
   configs = [:openstack_admin, :openstack_member]
   env     = Aviator::Test::Environment
 
-  [:username, :password, :tenantName].each do |key|
+  [:username, :password, :tenantName, :tokenId].each do |key|
     configs.each do |config|
-      c.filter_sensitive_data("<#{ config.to_s.upcase }_#{key.to_s.upcase}>") { env.send(config)[:auth_credentials][key]  }
+      c.filter_sensitive_data("<#{ config.to_s.upcase }_#{key.to_s.upcase}>") do
+        env.send(config)[:auth_credentials][key] || env.send(config)[:auth_credentials][key.to_s.underscore]
+      end
     end
   end
 


### PR DESCRIPTION
Since it's more common to use underscored_variable_capitalization,
the example config files should be updated to reflect that.
