### PR TITLE
Add bootstrap auth info when validating session

### DIFF
--- a/lib/aviator/core/session.rb
+++ b/lib/aviator/core/session.rb
@@ -112,7 +112,9 @@ module Aviator
       raise NotAuthenticatedError.new unless authenticated?
       raise ValidatorNotDefinedError.new unless environment[:auth_service][:validator]
 
-      response = auth_service.request environment[:auth_service][:validator].to_sym, session_data: auth_info
+      auth_with_bootstrap = auth_info.merge({ auth_service: environment[:auth_service] })
+
+      response = auth_service.request environment[:auth_service][:validator].to_sym, session_data: auth_with_bootstrap
 
       response.status == 200 || response.status == 203
     end

--- a/lib/aviator/openstack/common/v2/public/base.rb
+++ b/lib/aviator/openstack/common/v2/public/base.rb
@@ -18,7 +18,9 @@ module Aviator
 
 
     def base_url
-      if session_data[:base_url]
+      if session_data[:auth_service] && session_data[:auth_service][:host_uri]
+        "#{ session_data[:auth_service][:host_uri] }/v2.0"
+      elsif session_data[:base_url]
         session_data[:base_url]
       else
         service_spec = session_data[:access][:serviceCatalog].find { |s| s[:type] == service.to_s }

--- a/test/aviator/core/session_test.rb
+++ b/test/aviator/core/session_test.rb
@@ -23,26 +23,26 @@ class Aviator::Test
     end
 
 
-    describe '#authenticate' do      
+    describe '#authenticate' do
 
       it 'authenticates against the auth service indicated in the config file' do
         session = new_session
-        
+
         session.authenticate
 
         session.authenticated?.must_equal true
       end
-            
-            
+
+
       it 'authenticates against the auth service using the credentials in the given block' do
         session     = new_session
         credentials = config.openstack_admin[:auth_credentials]
-        
+
         session.authenticate do |c|
           c[:username] = credentials[:username]
           c[:password] = credentials[:password]
         end
-        
+
         session.authenticated?.must_equal true
       end
 
@@ -50,46 +50,46 @@ class Aviator::Test
       it 'raises an AuthenticationError when authentication fails' do
         session     = new_session
         credentials = config.openstack_admin[:auth_credentials]
-        
+
         the_method = lambda do
           session.authenticate do |c|
             c[:username] = 'invalidusername'
             c[:password] = 'invalidpassword'
           end
         end
-        
+
         the_method.must_raise Aviator::Session::AuthenticationError
       end
-      
-      
+
+
       it 'updates the session data of its service objects' do
         session = new_session
         session.authenticate
-        
+
         keystone = session.identity_service
-        
+
         session_data_1 = keystone.default_session_data
-        
+
         session.authenticate
-        
+
         session.identity_service.must_equal keystone
-        
+
         new_token = session.identity_service.default_session_data[:access][:token][:id]
         new_token.wont_equal session_data_1[:access][:token][:id]
         keystone.default_session_data[:access][:token][:id].must_equal new_token
       end
 
     end # describe '#authenticate'
-    
-    
+
+
     describe '#dump' do
-      
+
       it 'serializes the session data for caching' do
         session = new_session
         session.authenticate
-        
+
         str = session.dump
-        
+
         expected = JSON.generate({
           environment: session.send(:environment),
           auth_info: session.send(:auth_info)
@@ -97,21 +97,21 @@ class Aviator::Test
 
         str.must_equal expected
       end
-      
+
     end
 
 
     describe '#load' do
-      
+
       it 'returns itself' do
         session = new_session
         session.authenticate
-        
+
         str = session.dump
         session.load(str).must_equal session
       end
 
-      
+
       it 'updates the session data of its service objects' do
         session1 = new_session
         session1.authenticate
@@ -128,101 +128,114 @@ class Aviator::Test
       end
 
     end # describe '#load'
-    
-    
+
+
     describe '::load' do
-      
+
       it 'creates a new instance from the given session dump' do
         session = new_session
         session.authenticate
-        
+
         str      = session.dump
         session  = Aviator::Session.load(str)
         expected = JSON.parse(str).with_indifferent_access
-        
+
         session.dump.must_equal str
         session.authenticated?.must_equal true
-        
-        # This is bad testing practice (testing a private method) but 
+
+        # This is bad testing practice (testing a private method) but
         # I'll go ahead and do it anyway just to be sure.
         session.send(:environment).must_equal expected[:environment]
         session.send(:auth_info).must_equal   expected[:auth_info]
       end
-      
-      
+
+
       it 'uses the loaded auth info for its services' do
         session = new_session
         session.authenticate
-        
+
         expected = JSON.parse(session.dump).with_indifferent_access
         session  = Aviator::Session.load(session.dump)
         service  = session.identity_service
-        
+
         service.default_session_data.must_equal expected[:auth_info]
       end
-      
+
     end
-    
-    
+
+
     describe '::new' do
-      
+
       it 'directs log entries to the given log file' do
         log_file_path.delete if log_file_path.file?
-        
+
         session = new_session
         session.authenticate
 
         log_file_path.file?.must_equal true
       end
-      
+
     end
-    
-    
+
+
     describe '#validate' do
-      
+
       it 'returns true if session is still valid' do
         session = new_session
         session.authenticate
-        
+
         session.validate.must_equal true
       end
-      
-      
+
+
       it 'returns false if session is no longer valid' do
         session = new_session
         session.authenticate
-        
+
         session.send(:auth_info)[:access][:token][:id] = 'invalidtokenid'
-        
+
         session.validate.must_equal false
       end
-      
-      
+
+
       it 'raises an error if called before authenticating' do
         the_method = lambda { new_session.validate }
-        
+
         the_method.must_raise Aviator::Session::NotAuthenticatedError
       end
-      
+
+
+      it 'returns true even when a default token is used' do
+        session = new_session
+        credentials = config.openstack_admin[:auth_credentials]
+
+        session.authenticate do |c|
+          c[:username] = credentials[:username]
+          c[:password] = credentials[:password]
+        end
+
+        session.validate.must_equal true
+      end
+
     end
-    
-    
+
+
     describe '#xxx_service' do
-      
+
       it 'raises a NotAuthenticatedError if called without authenticating first' do
         the_method = lambda { new_session.identity_service }
-        
+
         the_method.must_raise Aviator::Session::NotAuthenticatedError
       end
-      
-      
+
+
       it 'returns an instance of the indicated service' do
         session = new_session
         session.authenticate
-        
+
         session.identity_service.wont_be_nil
       end
-      
+
     end
 
   end # describe 'aviator/core/service'

--- a/test/cassettes/core/session/i_validate/returns_false_if_session_is_no_longer_valid.yml
+++ b/test/cassettes/core/session/i_validate/returns_false_if_session_is_no_longer_valid.yml
@@ -21,20 +21,20 @@ http_interactions:
       content-type:
       - application/json
       content-length:
-      - '2657'
+      - '2773'
       date:
-      - Wed, 04 Sep 2013 21:36:55 GMT
+      - Mon, 07 Oct 2013 23:31:07 GMT
       connection:
       - close
     body:
       encoding: US-ASCII
-      string: ! '{"access": {"token": {"issued_at": "2013-09-04T21:36:55.376289",
-        "expires": "2013-09-05T21:36:55Z", "id": "2be42e49dfcf4b548bb2488321bd51a7",
-        "tenant": {"description": null, "enabled": true, "id": "99ac3327702a4da09fd2513fe7d8e5bf",
-        "name": "<OPENSTACK_ADMIN_TENANTNAME>"}}, "serviceCatalog": [{"endpoints":
-        [{"adminURL": "http://192.168.56.11:8774/v2/99ac3327702a4da09fd2513fe7d8e5bf",
-        "region": "RegionOne", "internalURL": "http://192.168.56.11:8774/v2/99ac3327702a4da09fd2513fe7d8e5bf",
-        "id": "3b72a66bf2f0491bb8dba827cade0d48", "publicURL": "http://192.168.56.11:8774/v2/99ac3327702a4da09fd2513fe7d8e5bf"}],
+      string: ! '{"access": {"token": {"issued_at": "2013-10-07T23:31:07.084481",
+        "expires": "2013-10-08T23:31:07Z", "id": "97e1a34ffffc4e4abdf23aca07ab824c",
+        "tenant": {"description": "<OPENSTACK_ADMIN_TENANTNAME>", "enabled": true,
+        "id": "4a35c4710f7a4efaa348947fdb1b858f", "name": "<OPENSTACK_ADMIN_TENANTNAME>"}},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://192.168.56.11:8774/v2/4a35c4710f7a4efaa348947fdb1b858f",
+        "region": "RegionOne", "internalURL": "http://192.168.56.11:8774/v2/4a35c4710f7a4efaa348947fdb1b858f",
+        "id": "3b72a66bf2f0491bb8dba827cade0d48", "publicURL": "http://192.168.56.11:8774/v2/4a35c4710f7a4efaa348947fdb1b858f"}],
         "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
         "http://192.168.56.11:3333", "region": "RegionOne", "internalURL": "http://192.168.56.11:3333",
         "id": "482f749b370c40eab8788d6d0bc47f48", "publicURL": "http://192.168.56.11:3333"}],
@@ -45,9 +45,9 @@ http_interactions:
         "http://192.168.56.11:8777", "region": "RegionOne", "internalURL": "http://192.168.56.11:8777",
         "id": "4eb4edec1d2647bfb8ba4f9a5757169d", "publicURL": "http://192.168.56.11:8777"}],
         "endpoints_links": [], "type": "metering", "name": "ceilometer"}, {"endpoints":
-        [{"adminURL": "http://192.168.56.11:8776/v1/99ac3327702a4da09fd2513fe7d8e5bf",
-        "region": "RegionOne", "internalURL": "http://192.168.56.11:8776/v1/99ac3327702a4da09fd2513fe7d8e5bf",
-        "id": "009e8a41953d439f845b2a0c0dc28b73", "publicURL": "http://192.168.56.11:8776/v1/99ac3327702a4da09fd2513fe7d8e5bf"}],
+        [{"adminURL": "http://192.168.56.11:8776/v1/4a35c4710f7a4efaa348947fdb1b858f",
+        "region": "RegionOne", "internalURL": "http://192.168.56.11:8776/v1/4a35c4710f7a4efaa348947fdb1b858f",
+        "id": "009e8a41953d439f845b2a0c0dc28b73", "publicURL": "http://192.168.56.11:8776/v1/4a35c4710f7a4efaa348947fdb1b858f"}],
         "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
         [{"adminURL": "http://192.168.56.11:8773/services/Admin", "region": "RegionOne",
         "internalURL": "http://192.168.56.11:8773/services/Cloud", "id": "6820836ec6834548bf7b54da0271dded",
@@ -56,14 +56,15 @@ http_interactions:
         "region": "RegionOne", "internalURL": "http://192.168.56.11:5000/v2.0", "id":
         "24a95f51f67949e784971e97463ee4d8", "publicURL": "http://192.168.56.11:5000/v2.0"}],
         "endpoints_links": [], "type": "identity", "name": "keystone"}], "user": {"username":
-        "<OPENSTACK_ADMIN_USERNAME>", "roles_links": [], "id": "b4217edff9a14c3888439386a726ada9",
-        "roles": [{"name": "admin"}], "name": "<OPENSTACK_ADMIN_USERNAME>"}, "metadata":
-        {"is_admin": 0, "roles": ["01a81f2dbb3441f1aaa8fe68a7c6f546"]}}}'
+        "<OPENSTACK_ADMIN_USERNAME>", "roles_links": [], "id": "4088b95fef9e49059a303a853f33c3c1",
+        "roles": [{"name": "admin"}, {"name": "_member_"}], "name": "<OPENSTACK_ADMIN_USERNAME>"},
+        "metadata": {"is_admin": 0, "roles": ["01a81f2dbb3441f1aaa8fe68a7c6f546",
+        "9fe2ff9ee4384b1894a90878d3e92bab"]}}}'
     http_version: 
-  recorded_at: Wed, 04 Sep 2013 21:36:47 GMT
+  recorded_at: Mon, 07 Oct 2013 23:45:43 GMT
 - request:
     method: get
-    uri: http://192.168.56.11:5000/v2.0/tenants
+    uri: <OPENSTACK_ADMIN_HOST_URI>:5000/v2.0/tenants
     body:
       encoding: US-ASCII
       string: ''
@@ -86,7 +87,7 @@ http_interactions:
       content-length:
       - '100'
       date:
-      - Wed, 04 Sep 2013 21:36:55 GMT
+      - Mon, 07 Oct 2013 23:31:07 GMT
       connection:
       - close
     body:
@@ -94,5 +95,5 @@ http_interactions:
       string: ! '{"error": {"message": "Could not find token: invalidtokenid", "code":
         401, "title": "Unauthorized"}}'
     http_version: 
-  recorded_at: Wed, 04 Sep 2013 21:36:47 GMT
+  recorded_at: Mon, 07 Oct 2013 23:45:43 GMT
 recorded_with: VCR 2.5.0

--- a/test/cassettes/core/session/i_validate/returns_true_even_when_a_default_token_is_used.yml
+++ b/test/cassettes/core/session/i_validate/returns_true_even_when_a_default_token_is_used.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: <OPENSTACK_ADMIN_HOST_URI>:5000/v2.0/tokens
+    body:
+      encoding: UTF-8
+      string: ! '{"auth":{"passwordCredentials":{"username":"<OPENSTACK_ADMIN_USERNAME>","password":"<OPENSTACK_ADMIN_PASSWORD>"}}}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v0.8.8
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      vary:
+      - X-Auth-Token
+      content-type:
+      - application/json
+      content-length:
+      - '353'
+      date:
+      - Mon, 07 Oct 2013 23:31:07 GMT
+      connection:
+      - close
+    body:
+      encoding: US-ASCII
+      string: ! '{"access": {"token": {"issued_at": "2013-10-07T23:31:07.964949",
+        "expires": "2013-10-08T23:31:07Z", "id": "4c75a72240fa4ad2b5922756eb4f0db8"},
+        "serviceCatalog": [], "user": {"username": "<OPENSTACK_ADMIN_USERNAME>", "roles_links":
+        [], "id": "4088b95fef9e49059a303a853f33c3c1", "roles": [], "name": "<OPENSTACK_ADMIN_USERNAME>"},
+        "metadata": {"is_admin": 0, "roles": []}}}'
+    http_version: 
+  recorded_at: Mon, 07 Oct 2013 23:45:43 GMT
+- request:
+    method: get
+    uri: <OPENSTACK_ADMIN_HOST_URI>:5000/v2.0/tenants
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v0.8.8
+      X-Auth-Token:
+      - 4c75a72240fa4ad2b5922756eb4f0db8
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      vary:
+      - X-Auth-Token
+      content-type:
+      - application/json
+      content-length:
+      - '176'
+      date:
+      - Mon, 07 Oct 2013 23:31:07 GMT
+      connection:
+      - close
+    body:
+      encoding: US-ASCII
+      string: ! '{"tenants_links": [], "tenants": [{"description": "<OPENSTACK_ADMIN_TENANTNAME>",
+        "enabled": true, "id": "4a35c4710f7a4efaa348947fdb1b858f", "name": "<OPENSTACK_ADMIN_TENANTNAME>"}]}'
+    http_version: 
+  recorded_at: Mon, 07 Oct 2013 23:45:43 GMT
+recorded_with: VCR 2.5.0

--- a/test/cassettes/core/session/i_validate/returns_true_if_session_is_still_valid.yml
+++ b/test/cassettes/core/session/i_validate/returns_true_if_session_is_still_valid.yml
@@ -21,20 +21,20 @@ http_interactions:
       content-type:
       - application/json
       content-length:
-      - '2657'
+      - '2773'
       date:
-      - Wed, 04 Sep 2013 21:36:55 GMT
+      - Mon, 07 Oct 2013 23:31:07 GMT
       connection:
       - close
     body:
       encoding: US-ASCII
-      string: ! '{"access": {"token": {"issued_at": "2013-09-04T21:36:55.751208",
-        "expires": "2013-09-05T21:36:55Z", "id": "814bf20372294b50ae7fb554273fa652",
-        "tenant": {"description": null, "enabled": true, "id": "99ac3327702a4da09fd2513fe7d8e5bf",
-        "name": "<OPENSTACK_ADMIN_TENANTNAME>"}}, "serviceCatalog": [{"endpoints":
-        [{"adminURL": "http://192.168.56.11:8774/v2/99ac3327702a4da09fd2513fe7d8e5bf",
-        "region": "RegionOne", "internalURL": "http://192.168.56.11:8774/v2/99ac3327702a4da09fd2513fe7d8e5bf",
-        "id": "3b72a66bf2f0491bb8dba827cade0d48", "publicURL": "http://192.168.56.11:8774/v2/99ac3327702a4da09fd2513fe7d8e5bf"}],
+      string: ! '{"access": {"token": {"issued_at": "2013-10-07T23:31:07.572119",
+        "expires": "2013-10-08T23:31:07Z", "id": "4b8cea556f454aae89a751227ea98217",
+        "tenant": {"description": "<OPENSTACK_ADMIN_TENANTNAME>", "enabled": true,
+        "id": "4a35c4710f7a4efaa348947fdb1b858f", "name": "<OPENSTACK_ADMIN_TENANTNAME>"}},
+        "serviceCatalog": [{"endpoints": [{"adminURL": "http://192.168.56.11:8774/v2/4a35c4710f7a4efaa348947fdb1b858f",
+        "region": "RegionOne", "internalURL": "http://192.168.56.11:8774/v2/4a35c4710f7a4efaa348947fdb1b858f",
+        "id": "3b72a66bf2f0491bb8dba827cade0d48", "publicURL": "http://192.168.56.11:8774/v2/4a35c4710f7a4efaa348947fdb1b858f"}],
         "endpoints_links": [], "type": "compute", "name": "nova"}, {"endpoints": [{"adminURL":
         "http://192.168.56.11:3333", "region": "RegionOne", "internalURL": "http://192.168.56.11:3333",
         "id": "482f749b370c40eab8788d6d0bc47f48", "publicURL": "http://192.168.56.11:3333"}],
@@ -45,9 +45,9 @@ http_interactions:
         "http://192.168.56.11:8777", "region": "RegionOne", "internalURL": "http://192.168.56.11:8777",
         "id": "4eb4edec1d2647bfb8ba4f9a5757169d", "publicURL": "http://192.168.56.11:8777"}],
         "endpoints_links": [], "type": "metering", "name": "ceilometer"}, {"endpoints":
-        [{"adminURL": "http://192.168.56.11:8776/v1/99ac3327702a4da09fd2513fe7d8e5bf",
-        "region": "RegionOne", "internalURL": "http://192.168.56.11:8776/v1/99ac3327702a4da09fd2513fe7d8e5bf",
-        "id": "009e8a41953d439f845b2a0c0dc28b73", "publicURL": "http://192.168.56.11:8776/v1/99ac3327702a4da09fd2513fe7d8e5bf"}],
+        [{"adminURL": "http://192.168.56.11:8776/v1/4a35c4710f7a4efaa348947fdb1b858f",
+        "region": "RegionOne", "internalURL": "http://192.168.56.11:8776/v1/4a35c4710f7a4efaa348947fdb1b858f",
+        "id": "009e8a41953d439f845b2a0c0dc28b73", "publicURL": "http://192.168.56.11:8776/v1/4a35c4710f7a4efaa348947fdb1b858f"}],
         "endpoints_links": [], "type": "volume", "name": "cinder"}, {"endpoints":
         [{"adminURL": "http://192.168.56.11:8773/services/Admin", "region": "RegionOne",
         "internalURL": "http://192.168.56.11:8773/services/Cloud", "id": "6820836ec6834548bf7b54da0271dded",
@@ -56,14 +56,15 @@ http_interactions:
         "region": "RegionOne", "internalURL": "http://192.168.56.11:5000/v2.0", "id":
         "24a95f51f67949e784971e97463ee4d8", "publicURL": "http://192.168.56.11:5000/v2.0"}],
         "endpoints_links": [], "type": "identity", "name": "keystone"}], "user": {"username":
-        "<OPENSTACK_ADMIN_USERNAME>", "roles_links": [], "id": "b4217edff9a14c3888439386a726ada9",
-        "roles": [{"name": "admin"}], "name": "<OPENSTACK_ADMIN_USERNAME>"}, "metadata":
-        {"is_admin": 0, "roles": ["01a81f2dbb3441f1aaa8fe68a7c6f546"]}}}'
+        "<OPENSTACK_ADMIN_USERNAME>", "roles_links": [], "id": "4088b95fef9e49059a303a853f33c3c1",
+        "roles": [{"name": "admin"}, {"name": "_member_"}], "name": "<OPENSTACK_ADMIN_USERNAME>"},
+        "metadata": {"is_admin": 0, "roles": ["01a81f2dbb3441f1aaa8fe68a7c6f546",
+        "9fe2ff9ee4384b1894a90878d3e92bab"]}}}'
     http_version: 
-  recorded_at: Wed, 04 Sep 2013 21:36:47 GMT
+  recorded_at: Mon, 07 Oct 2013 23:45:43 GMT
 - request:
     method: get
-    uri: http://192.168.56.11:5000/v2.0/tenants
+    uri: <OPENSTACK_ADMIN_HOST_URI>:5000/v2.0/tenants
     body:
       encoding: US-ASCII
       string: ''
@@ -73,7 +74,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.8.8
       X-Auth-Token:
-      - 814bf20372294b50ae7fb554273fa652
+      - 4b8cea556f454aae89a751227ea98217
   response:
     status:
       code: 200
@@ -84,16 +85,15 @@ http_interactions:
       content-type:
       - application/json
       content-length:
-      - '231'
+      - '176'
       date:
-      - Wed, 04 Sep 2013 21:36:55 GMT
+      - Mon, 07 Oct 2013 23:31:07 GMT
       connection:
       - close
     body:
       encoding: US-ASCII
-      string: ! '{"tenants_links": [], "tenants": [{"description": null, "enabled":
-        true, "id": "3cab25130620477b8b03f1bfa8741603", "name": "admin"}, {"description":
-        null, "enabled": true, "id": "99ac3327702a4da09fd2513fe7d8e5bf", "name": "<OPENSTACK_ADMIN_TENANTNAME>"}]}'
+      string: ! '{"tenants_links": [], "tenants": [{"description": "<OPENSTACK_ADMIN_TENANTNAME>",
+        "enabled": true, "id": "4a35c4710f7a4efaa348947fdb1b858f", "name": "<OPENSTACK_ADMIN_TENANTNAME>"}]}'
     http_version: 
-  recorded_at: Wed, 04 Sep 2013 21:36:47 GMT
+  recorded_at: Mon, 07 Oct 2013 23:45:43 GMT
 recorded_with: VCR 2.5.0


### PR DESCRIPTION
Without the bootstrap info, service will try to look for endpoints
the usual way (via service catalog) which will be empty when
using default tokens. This fixes that problem.
