### PR TITLE
Remove activesupport dependency

### DIFF
--- a/aviator.gemspec
+++ b/aviator.gemspec
@@ -22,13 +22,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'faraday', '0.8.8'
-
-  if Aviator::Compatibility::RUBY_1_8_MODE
-    spec.add_dependency 'activesupport', '~> 2.0'
-  else
-    spec.add_dependency 'activesupport', '>= 3.2.8'
-  end
-
   spec.add_dependency 'thor', '~> 0.18.1'
   spec.add_dependency 'terminal-table', '>= 1.4.5'
 

--- a/lib/aviator/core.rb
+++ b/lib/aviator/core.rb
@@ -1,8 +1,8 @@
 require 'yaml'
 require 'json'
-require 'active_support/inflector'
 require 'faraday'
 
+require "aviator/string"
 require "aviator/version"
 require "aviator/compatibility"
 require "aviator/hashish"

--- a/lib/aviator/string.rb
+++ b/lib/aviator/string.rb
@@ -1,0 +1,18 @@
+class String
+
+  def camelize
+    word = self.slice(0,1).capitalize + self.slice(1..-1)
+    word.gsub(/_([a-zA-Z\d])/) { "#{$1.capitalize}" }
+  end
+
+  def constantize
+    self.split("::").inject(Object) do |namespace, sym|
+      namespace.const_get(sym.to_s.camelize, false)
+    end
+  end
+
+  def underscore
+    self.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase
+  end
+
+end


### PR DESCRIPTION
Replace activesupport/inflection calls with our own,
Aviator-specific implementation.

Change-Id: I4e95f0b95ebc9eae5486fdc8ec0eab66bf00b7b9
