### PR TITLE
Define inflections only when they're not already defined

### DIFF
--- a/lib/aviator/string.rb
+++ b/lib/aviator/string.rb
@@ -1,18 +1,24 @@
 class String
 
-  def camelize
-    word = self.slice(0,1).capitalize + self.slice(1..-1)
-    word.gsub(/_([a-zA-Z\d])/) { "#{$1.capitalize}" }
-  end
-
-  def constantize
-    self.split("::").inject(Object) do |namespace, sym|
-      namespace.const_get(sym.to_s.camelize, false)
+  unless instance_methods.include? 'camelize'
+    define_method :camelize do
+      word = self.slice(0,1).capitalize + self.slice(1..-1)
+      word.gsub(/_([a-zA-Z\d])/) { "#{$1.capitalize}" }
     end
   end
 
-  def underscore
-    self.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase
+  unless instance_methods.include? 'constantize'
+    define_method :constantize do
+      self.split("::").inject(Object) do |namespace, sym|
+        namespace.const_get(sym.to_s.camelize, false)
+      end
+    end
+  end
+
+  unless instance_methods.include? 'underscore'
+    define_method :underscore do
+      self.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase
+    end
   end
 
 end


### PR DESCRIPTION
This is so that Aviator doesn’t step on ActiveSupport’s toes in case
it’s already loaded into memory.

This is not the best solution since Aviator’s implementation may
diverge from ActiveSupport’s implementation at some point. For
now, this will have to do.

Change-Id: Iaf99d9499394c4a5ce1c0141f1a68492bb2f3191
