### PR TITLE
Remove OpenStack-specific code from Core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gemspec
 group :test do
   if Aviator::Compatibility::RUBY_1_8_MODE
     gem 'mime-types', '~> 1.25.1'
+    gem 'rest-client', '~> 1.6.7'
   end
 
   gem 'rake'

--- a/lib/aviator/core.rb
+++ b/lib/aviator/core.rb
@@ -12,3 +12,5 @@ require "aviator/core/response"
 require "aviator/core/service"
 require "aviator/core/session"
 require "aviator/core/logger"
+
+require "aviator/openstack"

--- a/lib/aviator/core/session.rb
+++ b/lib/aviator/core/session.rb
@@ -182,9 +182,11 @@ module Aviator
       @auth_info   = session_info[:auth_info]
     end
 
+
     def initialize_with_hash(hash_obj)
       @environment = Hashish.new(hash_obj)
     end
+
 
     def log_file
       @log_file

--- a/lib/aviator/openstack.rb
+++ b/lib/aviator/openstack.rb
@@ -1,0 +1,73 @@
+module Aviator
+
+  module Openstack
+
+    class << self
+
+      def find_request(service, name, session_data, options)
+        endpoint_type = options[:endpoint_type]
+        endpoint_types = if endpoint_type
+                           [endpoint_type.to_s.camelize]
+                         else
+                           ['Public', 'Admin']
+                         end
+
+        namespace = Aviator.const_get('Openstack') \
+                           .const_get(service.camelize)
+
+        version = infer_version(session_data, name, service).to_s.camelize
+
+        return nil unless version && namespace.const_defined?(version)
+
+        namespace = namespace.const_get(version, name)
+
+        endpoint_types.each do |endpoint_type|
+          name = name.to_s.camelize
+
+          next unless namespace.const_defined?(endpoint_type)
+          next unless namespace.const_get(endpoint_type).const_defined?(name)
+
+          return namespace.const_get(endpoint_type).const_get(name)
+        end
+
+        nil
+      end
+
+
+      def infer_version(session_data, request_name, service)
+        if session_data.has_key?(:auth_service) && session_data[:auth_service][:api_version]
+        session_data[:auth_service][:api_version].to_sym
+
+        elsif session_data.has_key?(:auth_service) && session_data[:auth_service][:host_uri]
+          m = session_data[:auth_service][:host_uri].match(/(v\d+)\.?\d*/)
+          return m[1].to_sym unless m.nil?
+
+        elsif session_data.has_key? :base_url
+          m = session_data[:base_url].match(/(v\d+)\.?\d*/)
+          return m[1].to_sym unless m.nil?
+
+        elsif session_data.has_key? :access
+          service_spec = session_data[:access][:serviceCatalog].find{|s| s[:type] == service }
+          raise Aviator::Service::MissingServiceEndpointError.new(service.to_s, request_name) unless service_spec
+          version = service_spec[:endpoints][0][:publicURL].match(/(v\d+)\.?\d*/)
+          version ? version[1].to_sym : :v1
+        end
+      end
+
+
+      def request_file_paths(service)
+          Dir.glob(Pathname.new(__FILE__).join(
+            '..',
+            'openstack',
+             service.to_s,
+            '**',
+            '*.rb'
+            ).expand_path
+          )
+      end
+
+    end # class << self
+
+  end # module Openstack
+
+end


### PR DESCRIPTION
This removes the remaining provider-specific code from Aviator so that we
can potentially use it for other cloud providers. Phase 2 of this change
will involve moving Openstack-specific code to its own project.

Change-Id: I8a74adf009bc678e2aaecf3b91010e2dfe492418
