### PR TITLE
Allow api_version override

### DIFF
--- a/lib/aviator/core/service.rb
+++ b/lib/aviator/core/service.rb
@@ -29,8 +29,8 @@ module Aviator
 
 
     class UnknownRequestError < StandardError
-      def initialize(request_name)
-        super "Unknown request #{ request_name }."
+      def initialize(request_name, options)
+        super "Unknown request #{ request_name } #{ options }."
       end
     end
 
@@ -60,6 +60,7 @@ module Aviator
       @provider = opts[:provider] || (raise ProviderNotDefinedError.new)
       @service  = opts[:service]  || (raise ServiceNameNotDefinedError.new)
       @log_file = opts[:log_file]
+      @default_options = opts[:default_options] || {}
 
       @default_session_data = opts[:default_session_data]
 
@@ -68,6 +69,10 @@ module Aviator
 
 
     def request(request_name, options={}, &params)
+      if options[:api_version].nil? && @default_options[:api_version]
+        options[:api_version] = @default_options[:api_version]
+      end
+
       session_data = options[:session_data] || default_session_data
 
       raise SessionDataNotProvidedError.new unless session_data
@@ -78,7 +83,7 @@ module Aviator
 
       request_class = provider_module.find_request(service, request_name, session_data, options)
 
-      raise UnknownRequestError.new(request_name) unless request_class
+      raise UnknownRequestError.new(request_name, options) unless request_class
 
       request  = request_class.new(session_data, &params)
 

--- a/lib/aviator/core/session.rb
+++ b/lib/aviator/core/session.rb
@@ -154,12 +154,17 @@ module Aviator
 
       @services ||= {}
 
-      @services[service_name] ||= Service.new(
-        :provider => environment[:provider],
-        :service  => service_name,
-        :default_session_data => auth_info,
-        :log_file => log_file
-      )
+      if @services[service_name].nil?
+        default_options = environment["#{ service_name }_service"]
+
+        @services[service_name] = Service.new(
+          :provider => environment[:provider],
+          :service  => service_name,
+          :default_session_data => auth_info,
+          :default_options => default_options,
+          :log_file => log_file
+        )
+      end
 
       @services[service_name]
     end

--- a/lib/aviator/openstack.rb
+++ b/lib/aviator/openstack.rb
@@ -16,7 +16,12 @@ module Aviator
         namespace = Aviator.const_get('Openstack') \
                            .const_get(service.camelize)
 
-        version = infer_version(session_data, name, service).to_s.camelize
+        if options[:api_version]
+          m = options[:api_version].to_s.match(/(v\d+)\.?\d*/)
+          version = m[1].to_s.camelize unless m.nil?
+        end
+
+        version ||= infer_version(session_data, name, service).to_s.camelize
 
         return nil unless version && namespace.const_defined?(version)
 

--- a/test/aviator/openstack_test.rb
+++ b/test/aviator/openstack_test.rb
@@ -66,6 +66,29 @@ class Aviator::Test
       end
 
 
+      it 'can find the correct request class if based on the provided version' do
+        load_service
+
+        bootstrap = {
+          :auth_service => {
+            :name        => 'identity',
+            :host_uri    => 'http://devstack:5000',
+            :request     => 'create_token'
+          }
+        }
+        api_version = :v2
+        request_class = modyul.find_request(
+                            bootstrap[:auth_service][:name],
+                            bootstrap[:auth_service][:request],
+                            bootstrap,
+                            { :api_version => api_version }
+                        )
+
+        request_class.wont_be_nil
+        request_class.api_version.must_equal api_version
+      end
+
+
       it 'raises an error if session data does not have the endpoint information' do
         load_service
         request_name = config[:auth_service][:request].to_sym


### PR DESCRIPTION
This is an experimental patch that provides a caller two ways to override a request's api_version.

First method: In the call to a request.

```
   compute_service.request :create_server, :api_version => v1 { ... }
```

Second method: In the configuration file.

```
   production:
     provider: openstack
     auth_service:
       # declare auth service here
     compute_service:
       api_version: v2
```
