### PR TITLE
Require pathname

### DIFF
--- a/lib/aviator/core.rb
+++ b/lib/aviator/core.rb
@@ -1,6 +1,7 @@
 require 'yaml'
 require 'json'
 require 'faraday'
+require 'pathname'
 
 require "aviator/version"
 require "aviator/core/utils/string"


### PR DESCRIPTION
Without this patch, passing an invalid path into an Aviator::Session object
raises an uninitialized constant error when it should be raising an
InvalidConfigFilePathError. This patch adds the pathname gem to
lib/aviator/core.rb so that Pathname is accessible from other modules.
