### PR TITLE
Use regular hash instead of Hashish object in session dump

### DIFF
--- a/lib/aviator/core/session.rb
+++ b/lib/aviator/core/session.rb
@@ -85,10 +85,10 @@ module Aviator
 
 
     def dump
-      JSON.generate(Hashish.new({
+      JSON.generate({
         :environment   => environment,
         :auth_response => auth_response
-      }))
+      })
     end
 
 


### PR DESCRIPTION
Without this patch, unit tests will fail intermittently on ruby 1.8.7. The
Hashish initializer calls the .dup method on its argument, and on 1.8.7 key
order is not guaranteed to be preserved. This causes the equality test for the
session to fail sometimes. This patch resolves the problem by using a regular
hash instead of a Hashish object in the session dump method. The dump method
does not need to use a Hashish object since it is immediately turning it into
JSON, which has no need to change symbols to strings and therefore has no need
to use the Hashish object.
