### PR TITLE
Only filter nil values when updating tenant properties

### DIFF
--- a/lib/aviator/openstack/identity/requests/v2/admin/update_tenant.rb
+++ b/lib/aviator/openstack/identity/requests/v2/admin/update_tenant.rb
@@ -21,7 +21,7 @@ module Aviator
       }
 
       [:name, :enabled, :description].each do |key|
-        p[:tenant][key] = params[key] if params[key]
+        p[:tenant][key] = params[key] unless params[key].nil?
       end
 
       p


### PR DESCRIPTION
Without this patch, updating a tenant to have a value of the boolean
false for the property "enabled" will silently fail. This is because the
update_tenant request will only modify properties if the parameters are
not falsey, and false is a falsey value. This patch fixes the problem
by modifying the update_tenant request to alter properties only when
they are not strictly nil.
