### PR TITLE
Remove the requirement to authenticate before calling a service object

### DIFF
--- a/lib/aviator/core/service.rb
+++ b/lib/aviator/core/service.rb
@@ -21,9 +21,17 @@ module Aviator
     end
 
     class SessionDataNotProvidedError < StandardError
-      def initialize
-        super "default_session_data is not initialized and no session data was "\
-              "provided in the method call."
+      def initialize(service_name, request_name)
+        super "\n\nERROR: default_session_data is not initialized and no session data was provided in\n"\
+              "the method call. You have two ways to fix this:\n\n"\
+              "   1) Call Session#authenticate before calling Session##{service_name}_service, or\n\n"\
+              "   2) If you're really sure you don't want to authenticate beforehand,\n"\
+              "      construct the method call this way:\n\n"\
+              "          service = session.#{service_name}_service\n"\
+              "          service.request :#{request_name}, :api_version => :v2, :session_data => sessiondatavar\n\n"\
+              "      Replace :v2 with whatever available version you want to use and make sure sessiondatavar\n"\
+              "      is a hash that contains, at least, the :base_url key. Other keys, such as :service_token may\n"\
+              "      be needed depending on what the request class you are calling requires.\n\n"
       end
     end
 
@@ -75,7 +83,7 @@ module Aviator
 
       session_data = options[:session_data] || default_session_data
 
-      raise SessionDataNotProvidedError.new unless session_data
+      raise SessionDataNotProvidedError.new(@service, request_name) unless session_data
 
       [:base_url].each do |k|
         session_data[k] = options[k] if options[k]

--- a/lib/aviator/core/session.rb
+++ b/lib/aviator/core/session.rb
@@ -152,8 +152,6 @@ module Aviator
 
 
     def get_service_obj(service_name)
-      raise NotAuthenticatedError.new unless self.authenticated?
-
       @services ||= {}
 
       if @services[service_name].nil?

--- a/test/aviator/core/session_test.rb
+++ b/test/aviator/core/session_test.rb
@@ -261,18 +261,17 @@ class Aviator::Test
 
     describe '#xxx_service' do
 
-      it 'raises a NotAuthenticatedError if called without authenticating first' do
-        the_method = lambda { new_session.identity_service }
-
-        the_method.must_raise Aviator::Session::NotAuthenticatedError
-      end
-
-
       it 'returns an instance of the indicated service' do
         session = new_session
         session.authenticate
 
         session.identity_service.wont_be_nil
+      end
+
+      it 'returns an instance of the indicated service even if not authenticated' do
+        session = new_session
+        session.compute_service.wont_be_nil
+        session.authenticated?.must_equal false
       end
 
     end


### PR DESCRIPTION
There is no reason for Session#get_service_obj to require
authentication and it can do its job perfectly without it. The only
reason I can see it doing that is so that Service#request doesn't
crash. However, upon looking at Service#request, it already has the
necessary checks to ensure it has the data it needs. I did, however,
add a more helpful error message in cases where the client code did
forget to initialize the session data before calling Service#request.
