### PR TITLE
OpenStack: Add the ability to use a service token

### DIFF
--- a/lib/aviator/openstack/common/requests/v0/public/base.rb
+++ b/lib/aviator/openstack/common/requests/v0/public/base.rb
@@ -12,6 +12,12 @@ module Aviator
         if self.anonymous?
           # do nothing
 
+        elsif session_data.has_key? :service_token
+          # service_token is the token that one would bootstrap OpenStack
+          # with during the installation process. This token can be used
+          # directly and does not require authentication beforehand.
+          h['X-Auth-Token'] = session_data[:service_token]
+
         elsif keystone_v2_style_session_data?
           h['X-Auth-Token'] = session_data[:body][:access][:token][:id]
 

--- a/test/aviator/openstack/common/requests/v0/public/base_test.rb
+++ b/test/aviator/openstack/common/requests/v0/public/base_test.rb
@@ -66,6 +66,19 @@ class Aviator::Test
 
     describe '#headers' do
 
+      it 'must know to extract a service token if provided' do
+        session_data = {
+          :base_url => 'http://example.com',
+          :service_token => 'sometokenipickedupfromsomewhere'
+        }
+        headers = { 'X-Auth-Token' => session_data[:service_token] }
+
+        request = create_request(session_data)
+
+        request.headers.must_equal headers
+      end
+
+
       it 'must know to extract token from a Keystone v2 auth info' do
         session_data = get_session_data(:v2)
         headers = { 'X-Auth-Token' => session_data[:body][:access][:token][:id] }


### PR DESCRIPTION
Service tokens can be used directly without pre-authentication. While
it's possible to use service tokens without this change, it is not
very obvious. This change makes the use of service tokens easier.
