### PR TITLE
Less confusing authentication

### DIFF
--- a/lib/aviator/core/session.rb
+++ b/lib/aviator/core/session.rb
@@ -76,6 +76,7 @@ module Aviator
       else
         raise AuthenticationError.new(response.body)
       end
+      self
     end
 
 


### PR DESCRIPTION
As is, Aviator::Session#authenticate retuns nil (falsey) on success.
