### PR TITLE
Relax runtime dependency requirements

### DIFF
--- a/aviator.gemspec
+++ b/aviator.gemspec
@@ -21,10 +21,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'faraday', '0.8.8'
-  spec.add_dependency 'thor', '~> 0.18.1'
+  # Runtime dependencies
+  spec.add_dependency 'faraday', '>= 0.8.8'
+  spec.add_dependency 'thor', '>= 0.18.1'
   spec.add_dependency 'terminal-table', '>= 1.4.5'
 
+  # Development dependencies. See Gemfile for more development deps.
   spec.add_development_dependency "bundler", ">= 1.0"
   spec.add_development_dependency 'rb-fsevent', '~> 0.9.0'
   spec.add_development_dependency 'guard', '~> 1.8.0'

--- a/test/support/vcr_setup.rb
+++ b/test/support/vcr_setup.rb
@@ -31,6 +31,17 @@ VCR.configure do |c|
     @vcr_json_body_matcher_registered = true
   end
 
+  unless @vcr_custom_headers_matcher_registered
+    # References:
+    #   From VCR :docs => http://goo.gl/j0fiJ
+    #   Discussion by :author => http://goo.gl/p9q4r
+    c.register_request_matcher :custom_headers do |r1, r2|
+      r1.headers["User-Agent"] = r2.headers["User-Agent"]
+      r1.headers == r2.headers
+    end
+    @vcr_custom_headers_matcher_registered = true
+  end
+
   #=========== BEGIN FILTERS FOR SENSITIVE DATA ===========
 
   configs = [:openstack_admin, :openstack_member]
@@ -80,7 +91,7 @@ VCR.configure do |c|
     # given example that needs one.
     :record => (ENV['CI'] || ENV['TRAVIS'] ? :none : :once),
 
-    :match_requests_on => [:method, :port, :path, :query, :headers, :json_body],
+    :match_requests_on => [:method, :port, :path, :query, :custom_headers, :json_body],
 
     # Strict mocking
     # Inspired :by => http://myronmars.to/n/dev-blog/2012/06/thoughts-on-mocking


### PR DESCRIPTION
It's never a good idea for a gem to have strict dependencies. A
problem with this though is that we will have to be diligent with
every new release of dependencies. There's no surefire way to prevent
breakage but relying on automated tests and the CI helps.

As part of this requirements relaxation, a change was done on the
VCR setup script such that it doesn't care what version of Faraday
is used.
