### PR TITLE
Catch invalid provider and service names

### DIFF
--- a/bin/aviator
+++ b/bin/aviator
@@ -8,7 +8,7 @@ module Aviator
 module CLI
 
   class Main < Thor
-    
+
     desc 'describe [PROVIDER] [SERVICE] [API_VERSION ENDPOINT_TYPE REQUEST_NAME]', 'Describes various parts of Aviator.'
     def describe(provider=nil, service=nil, api_version=nil, endpoint_type=nil, request=nil)
       if request
@@ -20,6 +20,8 @@ module CLI
       else
         puts Aviator::Describer.describe_aviator
       end
+    rescue Aviator::Describer::InvalidProviderNameError => e
+      puts e.message
     end
 
   end


### PR DESCRIPTION
This changes ensures that the CLI tool `aviator describe` does not
display a stacktrace when an invalid provider is given. The change
also includes further checks for when requests are not found for
a given service.
