### PR TITLE
accept extra attributes of user

### DIFF
--- a/lib/aviator/openstack/identity/requests/v2/admin/create_user.rb
+++ b/lib/aviator/openstack/identity/requests/v2/admin/create_user.rb
@@ -24,6 +24,7 @@ module Aviator
     param :email,     :required => false
     param :enabled,   :required => false
     param :tenantId,  :required => false, :alias => :tenant_id
+    param :extras,    :required => false
 
 
     def body

--- a/lib/aviator/openstack/identity/requests/v2/admin/update_user.rb
+++ b/lib/aviator/openstack/identity/requests/v2/admin/update_user.rb
@@ -20,6 +20,7 @@ module Aviator
     param :email,     :required => false
     param :enabled,   :required => false
     param :tenantId,  :required => false, :alias => :tenant_id
+    param :extras,    :required => false
 
 
     def body

--- a/test/aviator/openstack/identity/requests/v2/admin/create_user_test.rb
+++ b/test/aviator/openstack/identity/requests/v2/admin/create_user_test.rb
@@ -104,7 +104,8 @@ class Aviator::Test
       klass.optional_params.must_equal [
         :email,
         :enabled,
-        :tenantId
+        :tenantId,
+        :extras
       ]
     end
 

--- a/test/aviator/openstack/identity/requests/v2/admin/update_user_test.rb
+++ b/test/aviator/openstack/identity/requests/v2/admin/update_user_test.rb
@@ -86,7 +86,8 @@ class Aviator::Test
         :password,
         :email,
         :enabled,
-        :tenantId
+        :tenantId,
+        :extras
       ]
     end
 


### PR DESCRIPTION
keystone supports storing extra attributes for user. With this change,
extra attributes can be stored.

https://github.com/openstack/keystone/blob/c4c8d0b99a0404f4dcdb2f87c48fe15ee1526197/doc/source/api_curl_examples.rst
