### PR TITLE
Remove String monkeypatch

### DIFF
--- a/lib/aviator/core/cli/describer.rb
+++ b/lib/aviator/core/cli/describer.rb
@@ -33,8 +33,9 @@ module Aviator
 
     def self.describe_request(provider_name, service_name, api_version, endpoint_type, request_name)
       service = Aviator::Service.new :provider => provider_name, :service => service_name
-      request_class = "Aviator::#{ provider_name.camelize }::#{ service_name.camelize }::Requests::"\
-                      "#{ api_version.camelize }::#{ endpoint_type.camelize }::#{ request_name.camelize }".constantize
+      request_class = "Aviator::#{ StrUtil.camelize(provider_name) }::#{ StrUtil.camelize(service_name) }::Requests::"\
+                      "#{ StrUtil.camelize(api_version) }::#{ StrUtil.camelize(endpoint_type) }::#{ StrUtil.camelize(request_name) }"
+      request_class = StrUtil.constantize(request_class)
 
       display = "Request: #{ request_name }\n"
 
@@ -119,7 +120,7 @@ module Aviator
         str = "Available requests for #{ provider_name } #{ service_name }_service:\n"
 
         requests.each do |klass|
-          str << "  #{ klass.api_version } #{ klass.endpoint_type } #{ klass.name.split('::').last.underscore }\n"
+          str << "  #{ klass.api_version } #{ klass.endpoint_type } #{ StrUtil.underscore(klass.name.split('::').last) }\n"
         end
 
         str

--- a/lib/aviator/core/request_builder.rb
+++ b/lib/aviator/core/request_builder.rb
@@ -40,12 +40,12 @@ module Aviator
         ]
 
         namespace = namespace_arr.inject(root_namespace) do |namespace, sym|
-          const_name = sym.to_s.camelize
+          const_name = StrUtil.camelize(sym.to_s)
           namespace.const_set(const_name, Module.new) unless namespace.const_defined?(const_name, false)
           namespace.const_get(const_name, false)
         end
 
-        klassname = request_name.to_s.camelize
+        klassname = StrUtil.camelize(request_name.to_s)
 
         if namespace.const_defined?(klassname, false)
           raise RequestAlreadyDefinedError.new(namespace, klassname)
@@ -66,11 +66,11 @@ module Aviator
         end
 
         full_request_class_arr.inject(root_namespace) do |namespace, sym|
-          namespace.const_get(sym.to_s.camelize, false)
+          namespace.const_get(StrUtil.camelize(sym.to_s), false)
         end
       rescue NameError => e
-        if Aviator.const_defined?(full_request_class_arr[0].to_s.camelize)
-          provider = "Aviator::#{ full_request_class_arr[0] }::Provider".constantize
+        if Aviator.const_defined?(StrUtil.camelize(full_request_class_arr[0].to_s))
+          provider = StrUtil.constantize("Aviator::#{ full_request_class_arr[0] }::Provider")
           arr = ['..'] + full_request_class_arr
           arr[-1,1] = arr.last.to_s + '.rb'
           path = Pathname.new(provider.root_dir).join(*arr.map{|i| i.to_s }).expand_path
@@ -79,7 +79,7 @@ module Aviator
         if provider && path.exist?
           require path
           full_request_class_arr.inject(root_namespace) do |namespace, sym|
-            namespace.const_get(sym.to_s.camelize, false)
+            namespace.const_get(StrUtil.camelize(sym.to_s), false)
           end
         else
           raise BaseRequestNotFoundError.new(request_class_arr)

--- a/lib/aviator/core/service.rb
+++ b/lib/aviator/core/service.rb
@@ -47,7 +47,7 @@ module Aviator
 
     class MissingServiceEndpointError < StandardError
       def initialize(service_name, request_name)
-        request_name = request_name.to_s.split('::').last.underscore
+        request_name = StrUtil.underscore(request_name.to_s.split('::').last)
         super "The session's service catalog does not have an entry for the #{ service_name } "\
               "service. Therefore, I don't know to which base URL the request should be sent. "\
               "This may be because you are using a default or unscoped token. If this is not your "\
@@ -147,10 +147,10 @@ module Aviator
 
       constant_parts = request_file_paths \
                         .map{|rf| rf.to_s.match(/#{provider}\/#{service}\/([\w\/]+)\.rb$/) } \
-                        .map{|rf| rf[1].split('/').map{|c| c.camelize }.join('::') }
+                        .map{|rf| rf[1].split('/').map{|c| StrUtil.camelize(c) }.join('::') }
 
       @request_classes = constant_parts.map do |cp|
-        "Aviator::#{provider.camelize}::#{service.camelize}::#{cp}".constantize
+        StrUtil.constantize("Aviator::#{StrUtil.camelize(provider)}::#{StrUtil.camelize(service)}::#{cp}")
       end
     end
 
@@ -161,7 +161,7 @@ module Aviator
 
 
     def provider_module
-      @provider_module ||= "Aviator::#{provider.camelize}::Provider".constantize
+      @provider_module ||= StrUtil.constantize("Aviator::#{StrUtil.camelize(provider)}::Provider")
     end
 
   end

--- a/lib/aviator/core/utils/string.rb
+++ b/lib/aviator/core/utils/string.rb
@@ -1,24 +1,26 @@
-class String
+module Aviator
 
-  unless instance_methods.include? 'camelize'
-    define_method :camelize do
-      word = self.slice(0,1).capitalize + self.slice(1..-1)
-      word.gsub(/_([a-zA-Z\d])/) { "#{$1.capitalize}" }
-    end
-  end
+  class StrUtil
 
-  unless instance_methods.include? 'constantize'
-    define_method :constantize do
-      self.split("::").inject(Object) do |namespace, sym|
-        namespace.const_get(sym.to_s.camelize, false)
+    class <<self
+
+      def camelize(str)
+        word = str.slice(0,1).capitalize + str.slice(1..-1)
+        word.gsub(/_([a-zA-Z\d])/) { "#{$1.capitalize}" }
       end
-    end
-  end
 
-  unless instance_methods.include? 'underscore'
-    define_method :underscore do
-      self.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase
+      def constantize(str)
+        str.split("::").inject(Object) do |namespace, sym|
+          namespace.const_get(self.camelize(sym.to_s), false)
+        end
+      end
+
+      def underscore(str)
+        str.gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase
+      end
+
     end
+
   end
 
 end

--- a/lib/aviator/openstack/provider.rb
+++ b/lib/aviator/openstack/provider.rb
@@ -95,24 +95,24 @@ EOF
         service = service.to_s
         endpoint_type = options[:endpoint_type]
         endpoint_types = if endpoint_type
-                           [endpoint_type.to_s.camelize]
+                           [StrUtil.camelize(endpoint_type.to_s)]
                          else
                            ['Public', 'Admin']
                          end
 
         namespace = Aviator.const_get('Openstack') \
-                           .const_get(service.camelize) \
+                           .const_get(StrUtil.camelize(service)) \
                            .const_get('Requests')
 
         if options[:api_version]
           m = options[:api_version].to_s.match(/(v\d+)\.?\d*/)
-          version = m[1].to_s.camelize unless m.nil?
+          version = StrUtil.camelize(m[1].to_s) unless m.nil?
         end
 
         version ||= infer_version(session_data, name, service)
 
         unless version.nil?
-          version = version.to_s.camelize
+          version = StrUtil.camelize(version.to_s)
         end
 
         return nil unless version && namespace.const_defined?(version)
@@ -120,7 +120,7 @@ EOF
         namespace = namespace.const_get(version, name)
 
         endpoint_types.each do |endpoint_type|
-          name = name.to_s.camelize
+          name = StrUtil.camelize(name.to_s)
 
           next unless namespace.const_defined?(endpoint_type)
           next unless namespace.const_get(endpoint_type).const_defined?(name)

--- a/test/aviator/core/cli/describer_test.rb
+++ b/test/aviator/core/cli/describer_test.rb
@@ -13,7 +13,7 @@ class Aviator::Test
         request_path = [provider_name, service_name, :requests, base_ver, base_ept, base_name]
 
         @base = request_path.inject(Aviator) do |namespace, sym|
-          const_name = sym.to_s.camelize
+          const_name = Aviator::StrUtil.camelize(sym.to_s)
 
           if namespace && namespace.const_defined?(const_name, false)
             namespace.const_get(const_name, false)
@@ -91,7 +91,7 @@ class Aviator::Test
         expected  = "Available requests for #{ provider } #{ service }_service:\n"
 
         requests.each do |klass|
-          expected << "  #{ klass.api_version } #{ klass.endpoint_type } #{ klass.name.split('::').last.underscore }\n"
+          expected << "  #{ klass.api_version } #{ klass.endpoint_type } #{ Aviator::StrUtil.underscore(klass.name.split('::').last) }\n"
         end
 
         klass.describe_service(provider, service).must_equal expected

--- a/test/aviator/core/request_builder_test.rb
+++ b/test/aviator/core/request_builder_test.rb
@@ -26,7 +26,7 @@ class Aviator::Test
         end
 
         [provider, service, :requests, api_ver, ep_type, _name_].inject(builder) do |namespace, sym|
-          const_name = sym.to_s.camelize
+          const_name = Aviator::StrUtil.camelize(sym.to_s)
 
           namespace.const_defined?(const_name, false).must_equal true
 
@@ -50,7 +50,7 @@ class Aviator::Test
         end
 
         [provider, service, :requests, api_ver, ep_type, _name_].inject(builder) do |namespace, sym|
-          const_name = sym.to_s.camelize
+          const_name = Aviator::StrUtil.camelize(sym.to_s)
 
           namespace.const_defined?(const_name, false).must_equal true,
             "Expected #{ const_name } to be defined in #{ namespace }"
@@ -96,7 +96,7 @@ class Aviator::Test
         ]
 
         child_request = child_req_hierarchy.inject(builder) do |namespace, sym|
-          namespace.const_get(sym.to_s.camelize, false)
+          namespace.const_get(Aviator::StrUtil.camelize(sym.to_s), false)
         end
 
         child_request.wont_be_nil
@@ -154,7 +154,7 @@ class Aviator::Test
         error = the_method.call rescue $!
 
         error.message.wont_be_nil
-        error.request_name.must_equal request[:name].to_s.camelize
+        error.request_name.must_equal Aviator::StrUtil.camelize(request[:name].to_s)
       end
 
 
@@ -165,11 +165,11 @@ class Aviator::Test
         builder.define_request child_arr.last, :inherit => base_arr do; end
 
         base_klass = base_arr.insert(2, :requests).inject(builder) do |namespace, sym|
-          namespace.const_get(sym.to_s.camelize, false)
+          namespace.const_get(Aviator::StrUtil.camelize(sym.to_s), false)
         end
 
         child_klass = child_arr.insert(2, :requests).inject(builder) do |namespace, sym|
-          namespace.const_get(sym.to_s.camelize, false)
+          namespace.const_get(Aviator::StrUtil.camelize(sym.to_s), false)
         end
 
         base_klass.wont_be_nil

--- a/test/aviator/core/service_test.rb
+++ b/test/aviator/core/service_test.rb
@@ -83,17 +83,18 @@ class Aviator::Test
       it 'returns an array of the request classes' do
         provider_name  = config[:provider]
         service_name    = config[:auth_service][:name]
-        provider_module = "Aviator::#{ provider_name.camelize }::Provider".constantize
+        provider_module = "Aviator::#{ Aviator::StrUtil.camelize(provider_name) }::Provider"
+        provider_module = Aviator::StrUtil.constantize(provider_module)
 
         request_file_paths = provider_module.request_file_paths(service_name)
         request_file_paths.each{ |path| require path }
 
         constant_parts = request_file_paths \
                           .map{|rf| rf.to_s.match(/#{ provider_name }\/#{ service_name }\/([\w\/]+)\.rb$/) } \
-                          .map{|rf| rf[1].split('/').map{|c| c.camelize }.join('::') }
+                          .map{|rf| rf[1].split('/').map{|c| Aviator::StrUtil.camelize(c) }.join('::') }
 
         classes = constant_parts.map do |cp|
-          "Aviator::#{ provider_name.camelize }::#{ service_name.camelize }::#{ cp }".constantize
+          Aviator::StrUtil.constantize("Aviator::#{ Aviator::StrUtil.camelize(provider_name) }::#{ Aviator::StrUtil.camelize(service_name) }::#{ cp }")
         end
 
         service.request_classes.must_equal classes

--- a/test/support/dummy/provider.rb
+++ b/test/support/dummy/provider.rb
@@ -8,8 +8,8 @@ module Provider
   class << self
 
     def find_request(service, name, session_data, options)
-      fqrn = "Aviator::Dummy::#{service.to_s.camelize}::Requests::V1::Public::#{name.to_s.camelize}"
-      fqrn.constantize
+      fqrn = "Aviator::Dummy::#{Aviator::StrUtil.camelize(service.to_s)}::Requests::V1::Public::#{Aviator::StrUtil.camelize(name.to_s)}"
+      Aviator::StrUtil.constantize(fqrn)
     rescue NameError => e
       raise NameError.new("#{fqrn} not found: #{e.message}")
     end

--- a/test/support/request_helper.rb
+++ b/test/support/request_helper.rb
@@ -50,7 +50,7 @@ class Test
 
 
       def get_request_class(parent, *path)
-        const_name = path.shift.to_s.camelize.gsub(/\.rb$/, '')
+        const_name = Aviator::StrUtil.camelize(path.shift.to_s).gsub(/\.rb$/, '')
 
         const = if parent.const_defined?(const_name)
                  parent.const_get(const_name)

--- a/test/support/test_base_class.rb
+++ b/test/support/test_base_class.rb
@@ -17,8 +17,9 @@ class Test < MiniTest::Spec
              .gsub(/^Aviator::Test::/, '') \
              .gsub(/::#/,  '/i_') \
              .gsub(/::::/, '/c_') \
-             .gsub(/::/,   '/') \
-             .underscore
+             .gsub(/::/,   '/')
+
+    path = Aviator::StrUtil.underscore(path)
 
     basename = __name__.gsub(/test_\d+_/, '')
 

--- a/test/support/vcr_setup.rb
+++ b/test/support/vcr_setup.rb
@@ -50,7 +50,7 @@ VCR.configure do |c|
   [:username, :password, :tenantName, :tokenId].each do |key|
     configs.each do |config|
       c.filter_sensitive_data("<#{ config.to_s.upcase }_#{key.to_s.upcase}>") do
-        env.send(config)[:auth_credentials][key] || env.send(config)[:auth_credentials][key.to_s.underscore]
+        env.send(config)[:auth_credentials][key] || env.send(config)[:auth_credentials][Aviator::StrUtil.underscore(key.to_s)]
       end
     end
   end


### PR DESCRIPTION
This change completely does away with string monkeypatching to avoid
any conflicts with ActiveSupport or other libraries that do the same
monkeypatching logic. We also completely avoid using ActiveSupport
since there may be clients that do not wish to include said gem into
their environment.